### PR TITLE
remove unnecessary dependencies from a couple targets

### DIFF
--- a/src/kinect-utils/CMakeLists.txt
+++ b/src/kinect-utils/CMakeLists.txt
@@ -15,6 +15,6 @@ pods_install_pkg_config_file(kinect-utils
     VERSION 0.0.1)
 
 add_executable(kinect-pc kinect-pc.cpp kinect-pointcloud-pub.cpp kinect-calib.c)
-pods_use_pkg_config_packages(kinect-pc glib-2.0 bot2-vis bot2-frames lcm bot2-core lcmtypes_kinect gthread-2.0)
+pods_use_pkg_config_packages(kinect-pc glib-2.0 lcm bot2-core lcmtypes_kinect gthread-2.0)
 target_link_libraries(kinect-pc z m ${LCMTYPES_LIBS}  boost_program_options boost_thread boost_system)
 pods_install_executables(kinect-pc)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,26 +1,15 @@
 find_package(PkgConfig REQUIRED)
 find_package(OpenGL REQUIRED)
-set(GLUT_LIBRARIES -lglut)
 
-pkg_check_modules(BOT2_CLURB bot2-core)
-if(NOT BOT2_CLURB_FOUND)
-    message("bot2-vis not found.  Not building libbot2 renderer")
-    return()
-endif(NOT BOT2_CLURB_FOUND)
 
 add_definitions(-Wall -std=gnu99)
 
 add_executable(kinect-rgb-tool rgb_tool.cpp)
 
-target_link_libraries(kinect-rgb-tool
-    ${GLUT_LIBRARIES})
-
 pods_use_pkg_config_packages(kinect-rgb-tool
     glib-2.0
-    bot2-vis
-    bot2-frames
-    bot2-param-client 
     lcm
+    bot2-core
     kinect-utils)
 
 pods_install_executables(kinect-rgb-tool)


### PR DESCRIPTION
 - kinect-rgb-tool does not depend on bot2-vis or GLUT
 - kinect-pc does not depend on bot2-vis